### PR TITLE
ONS-10 : Lock CMS build down to specific code release

### DIFF
--- a/pipeline/pipeline-cms.yml
+++ b/pipeline/pipeline-cms.yml
@@ -3,7 +3,7 @@ resources:
     type: git
     source:
       uri: https://github.com/ONSdigital/census-worth-self-help.git
-      branch: master
+      branch: v1.11.0
 
   - name: census-worth-self-help-content
     type: git
@@ -22,8 +22,7 @@ jobs:
     plan:
       - get: timer
       - get: github-site-code
-        trigger: true
-      - get: github-site-content
+      - get: census-worth-self-help-content
         trigger: true
 
       - task: deploy
@@ -46,7 +45,7 @@ jobs:
 
           inputs:
             - name: github-site-code
-            - name: github-site-content
+            - name: census-worth-self-help-content
 
           run:
             path: sh


### PR DESCRIPTION
This is temporary solution to allow new work to come into code master without CMS site update.

It is NOT the full work for ONS-10 which will make this a little more dynamic