### PR TITLE
ONS-409 : Remove role field

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -62,10 +62,6 @@ collections:
           displayFields: ["title"],
           multiple: true,
           required: true }
-      - { name: role,
-          label: Role,
-          required: false,
-          hint: "Please use Role(s) now." }
       - { name: body,
           label: Main Body,
           widget: sanitiziedMarkdown,


### PR DESCRIPTION
Role field no longer needed, the roles field (multi-value select) was added a couple of weeks ago.  We kept role field to help with migration.  PO has confirmed OK to now remove. Impact is that the field won't show up on the CMS anymore.