### PR TITLE
ONS-891: Implementing fix for bookmarks sometimes not being shown after a page refresh

### DIFF
--- a/site/src/pages/bookmarks.js
+++ b/site/src/pages/bookmarks.js
@@ -16,7 +16,7 @@ import PaginationBar from "../components/paginationbar"
 export default class Bookmarks extends React.Component {
   constructor(props) {
     super(props)
-
+    this.clientRendered = false;
     let paginator = new PaginationObject()
     this.state = {
       paginator: paginator
@@ -37,17 +37,26 @@ export default class Bookmarks extends React.Component {
     let bookmarkManager = new BookmarkManager()
     let bookmarkTitles = bookmarkManager.getTopBookmarks()
     let bookmarkEdges = bookmarkTitles
-      .map(title =>
-        this.data.allMarkdownRemark.edges.find(
-          edge => edge.node.frontmatter.title === title
-        )
-      )
-      .filter(edge => edge)
+    let showBookmarkBlock = false;
     let paginatedBookmarkEdges = this.state.paginator.filterResults(
       bookmarkEdges
     )
-
+    .map(title =>
+      this.data.allMarkdownRemark.edges.find(
+        edge => edge.node.frontmatter.title === title
+      )
+    )
+    .filter(edge => edge)
     bookmarkManager.addBookmarkClickEventToEdges(paginatedBookmarkEdges)
+      /*
+        Force a re-render once to make sure the Bookmark block content is properly updadted with Client side data.
+       */
+      if (this.clientRendered === false) {
+        this.clientRendered = true;
+        setTimeout(() => this.forceUpdate(), 0)
+      } else {
+        showBookmarkBlock = true
+      }
 
     return (
       <Layout explore_more_link={true}>
@@ -60,10 +69,10 @@ export default class Bookmarks extends React.Component {
           bookmark button in the article. Bookmarks are stored on your device,
           and are linked to your account, so only you have access to them.
         </TextBlock>
-        {bookmarkEdges.length > 0 && (
+        {showBookmarkBlock && paginatedBookmarkEdges.length > 0 && (
           <TabList elements={paginatedBookmarkEdges} />
         )}
-        {bookmarkEdges.length > 0 && (
+        {showBookmarkBlock && paginatedBookmarkEdges.length > 0 && (
           <PaginationBar
             total={bookmarkEdges.length}
             paginator={this.state.paginator}
@@ -71,7 +80,7 @@ export default class Bookmarks extends React.Component {
             onPageCount={paginatedBookmarkEdges.length}
           />
         )}
-        {bookmarkEdges.length === 0 && (
+        {showBookmarkBlock && paginatedBookmarkEdges.length === 0 && (
           <BlockStatus
             icon={<FontAwesomeIcon icon={faBookmark} />}
             title="Bookmarks will show here"


### PR DESCRIPTION
A few weeks ago, a similar problem was encountered with the most recent articles layout not being rendered correctly. A fix was implemented so that the component was forcefully updated a second time to have the data being properly in sync.

A similar approach was used for this ticket

We were unable to reproduce the problem locally so our first assumption is that somehow the data, although present in the local storage, is not rendered back into the application in time.